### PR TITLE
Upgrade Guzzle to ~6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": ">=4,<6",
+        "guzzlehttp/guzzle": "~6.0",
         "psr/log": "~1.0"
     },
     "autoload": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,9 +3,12 @@ namespace Jippi\Vault;
 
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\TransferException;
-use GuzzleHttp\Message\RequestInterface;
+use GuzzleHttp\Psr7\Request;
+
+use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+
 use Jippi\Vault\Exception\ClientException;
 use Jippi\Vault\Exception\ServerException;
 
@@ -14,59 +17,63 @@ class Client
     private $client;
     private $logger;
 
-    public function __construct(array $options = array(), LoggerInterface $logger = null, GuzzleClient $client = null)
+    public function __construct(array $options = [], LoggerInterface $logger = null, GuzzleClient $client = null)
     {
-        $options = array_replace(array(
-            'base_url' => 'http://127.0.0.1:8200',
-        ), $options);
+        $options = array_replace([
+            'base_uri' => 'http://127.0.0.1:8200',
+            'http_errors' => false,
+            'headers' => [
+                'User-Agent' => 'Vault-PHP-SDK/1.0',
+                'Content-Type' => 'application/json',
+            ],
+        ], $options);
 
         $this->client = $client ?: new GuzzleClient($options);
-        $this->client->setDefaultOption('exceptions', false);
         $this->logger = $logger ?: new NullLogger();
     }
 
-    public function get($url = null, array $options = array())
+    public function get($url = null, array $options = [])
     {
-        return $this->send($this->client->createRequest('GET', $url, $options));
+        return $this->send(new Request('GET', $url), $options);
     }
 
-    public function head($url, array $options = array())
+    public function head($url, array $options = [])
     {
-        return $this->send($this->client->createRequest('HEAD', $url, $options));
+        return $this->send(new Request('HEAD', $url), $options);
     }
 
-    public function delete($url, array $options = array())
+    public function delete($url, array $options = [])
     {
-        return $this->send($this->client->createRequest('DELETE', $url, $options));
+        return $this->send(new Request('DELETE', $url), $options);
     }
 
-    public function put($url, array $options = array())
+    public function put($url, array $options = [])
     {
-        return $this->send($this->client->createRequest('PUT', $url, $options));
+        return $this->send(new Request('PUT', $url), $options);
     }
 
-    public function patch($url, array $options = array())
+    public function patch($url, array $options = [])
     {
-        return $this->send($this->client->createRequest('PATCH', $url, $options));
+        return $this->send(new Request('PATCH', $url), $options);
     }
 
-    public function post($url, array $options = array())
+    public function post($url, array $options = [])
     {
-        return $this->send($this->client->createRequest('POST', $url, $options));
+        return $this->send(new Request('POST', $url), $options);
     }
 
-    public function options($url, array $options = array())
+    public function options($url, array $options = [])
     {
-        return $this->send($this->client->createRequest('OPTIONS', $url, $options));
+        return $this->send(new Request('OPTIONS', $url), $options);
     }
 
-    public function send(RequestInterface $request)
+    public function send(RequestInterface $request, $options = [])
     {
-        $this->logger->info(sprintf('%s "%s"', $request->getMethod(), $request->getUrl()));
-        $this->logger->debug(sprintf("Request:\n%s", (string) $request));
+        $this->logger->info(sprintf('%s "%s"', $request->getMethod(), $request->getUri()));
+        $this->logger->debug(sprintf("Request:\n%s\n%s\n%s", $request->getUri(), $request->getMethod(), json_encode($request->getHeaders())));
 
         try {
-            $response = $this->client->send($request);
+            $response = $this->client->send($request, $options);
         } catch (TransferException $e) {
             $message = sprintf('Something went wrong when calling vault (%s).', $e->getMessage());
 
@@ -75,14 +82,15 @@ class Client
             throw new ServerException($message);
         }
 
-        $this->logger->debug(sprintf("Response:\n%s", $response));
+        $this->logger->debug(sprintf("Response:\n%s", (string) $response->getBody()));
 
         if (400 <= $response->getStatusCode()) {
             $message = sprintf('Something went wrong when calling vault (%s - %s).', $response->getStatusCode(), $response->getReasonPhrase());
 
             $this->logger->error($message);
+            $this->logger->debug(sprintf("Response:\n%s\n%s\n%s", $response->getStatusCode(), json_encode($response->getHeaders()), $response->getBody()->getContents()));
 
-            $message .= "\n$response";
+            $message .= "\n" . (string) $response->getBody();
             if (500 <= $response->getStatusCode()) {
                 throw new ServerException($message, $response->getStatusCode(), $response);
             }

--- a/src/Services/Data.php
+++ b/src/Services/Data.php
@@ -18,7 +18,7 @@ class Data
     private $client;
 
     /**
-     * Create a new Sys service with an optional Client
+     * Create a new Data service with an optional Client
      *
      * @param Client|null $client
      */

--- a/src/Services/Sys.php
+++ b/src/Services/Sys.php
@@ -95,7 +95,7 @@ class Sys
      */
     public function sealed()
     {
-        return $this->sealStatus()->json()['sealed'];
+        return json_decode($this->sealStatus()->getBody(), true)['sealed'];
     }
 
     /**
@@ -105,7 +105,7 @@ class Sys
      */
     public function unsealed()
     {
-        return !$this->sealStatus()->json()['sealed'];
+        return !json_decode($this->sealStatus()->getBody(), true)['sealed'];
     }
 
     /**


### PR DESCRIPTION
This PR upgrades the SDK to use Guzzle 6.

I am still exercising these changes with functionality very similar to the examples (`shell.php` and `task.php`), hence the "hold" designation for now.

I am curious how others are using this SDK now or would like to in the future.

My initial use case is seeding vaults in developer and CI environments with secrets similar to the deployed environments.

This will likely be a small standalone application and/or repository (vs being called within another app).  Vault is already installed, configured, and running on the host via configuration management tool.

The examples already in the project do this vault seeding sequence very well for CakePHP apps, but I think there is an opportunity to implement some of this logic on a `Jippi\Vault\Helper` namespace very similar to the Consul SDK and be usable within any app or framework.

A "Seed" helper with some convenience methods fits my current use case well:

```
        $this->reset();

        $this->create();
        $this->unseal();

        $this->Vault->waitFor(['sealed' => false, 'standby' => false]);
        $this->Vault->clear();

        $this->mounts();
```

But there may be a better name or context than "seed" from which to offer these methods.
