### PR TITLE
remove duplicated function 'list' from Client.php

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -45,11 +45,6 @@ class Client
         return $this->send(new Request('GET', $url), $options);
     }
 
-    public function list($url = null, array $options = [])
-    {
-        return $this->send(new Request('LIST', $url), $options);
-    }
-
     public function head($url, array $options = [])
     {
         return $this->send(new Request('HEAD', $url), $options);


### PR DESCRIPTION
Sorry for bordering you again. I just notes it right now. The function 'list' already existed in the Class `Client.php`. I haven't seen that and I also don't know why PHP Storm didn't told me that. 

Anyway sorry for the inconvenience. 

Could you also create a new tag? :see_no_evil: 