### PR TITLE
protected properties: services and client

### DIFF
--- a/src/ServiceFactory.php
+++ b/src/ServiceFactory.php
@@ -6,14 +6,14 @@ use Psr\Log\LoggerInterface;
 
 class ServiceFactory
 {
-    private static $services = [
+    protected static $services = [
         'sys' => 'Jippi\Vault\Services\Sys',
         'data' => 'Jippi\Vault\Services\Data',
         'auth/token' => 'Jippi\Vault\Services\Auth\Token',
         'auth/approle'=>'Jippi\Vault\Services\Auth\AppRole'
     ];
 
-    private $client;
+    protected $client;
 
     public function __construct(array $options = array(), LoggerInterface $logger = null, GuzzleClient $guzzleClient = null)
     {


### PR DESCRIPTION
Would be better to make these properties protected. I don't want to fork it but and at the same time, I need to add some services. The best way to extend ServiceFactory but it useless all properties are private.