### PR TITLE
Upgraded guzzlehttp lisbrary from 6 to 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "~6.0",
+        "guzzlehttp/guzzle": "~7.0",
         "psr/log": "~1.0"
     },
     "autoload": {


### PR DESCRIPTION
Hello Christian.
As I see on [upgrading guide](https://github.com/guzzle/guzzle/blob/master/UPGRADING.md) those breaking changes are not affecting your library. So I decided to bump GuzzleHTTP version.