### PR TITLE
Support psr/log ^2.0 and ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "guzzlehttp/guzzle": "~7.0",
-        "psr/log": "~1.0"
+        "psr/log": "~1.0 | ^2.0 | ^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Since there is only log client used, the change doesn't affect anything but doesn't block update of psr/log 